### PR TITLE
Move Warning log statement for Hollow Knight

### DIFF
--- a/ports/released/hollow_knight/Hollow Knight.sh
+++ b/ports/released/hollow_knight/Hollow Knight.sh
@@ -47,10 +47,10 @@ else
         export MESA_GL_VERSION_OVERRIDE=3.3
         export MESA_GLSL_VERSION_OVERRIDE=330
         export MESA_NO_ASYNC_COMPILE=1
+
+	# Warn the user in log
+	echo "[WARNING] Overriding GL version to run the game; this may have unintended side effects or performance issues!"
     fi
-    
-    # Warn the user in log
-    echo "[WARNING] Overriding GL version to run the game; this may have unintended side effects or performance issues!"
 fi
 
 # Find game

--- a/ports/released/hollow_knight/Hollow Knight.sh
+++ b/ports/released/hollow_knight/Hollow Knight.sh
@@ -47,9 +47,8 @@ else
         export MESA_GL_VERSION_OVERRIDE=3.3
         export MESA_GLSL_VERSION_OVERRIDE=330
         export MESA_NO_ASYNC_COMPILE=1
-
-	# Warn the user in log
-	echo "[WARNING] Overriding GL version to run the game; this may have unintended side effects or performance issues!"
+		# Warn the user in log
+		echo "[WARNING] Overriding GL version to run the game; this may have unintended side effects or performance issues!"
     fi
 fi
 


### PR DESCRIPTION
This Warning about overriding the OpenGL version always prints, not just when the override env vars are being set. This PR moves the warning.