### PR TITLE
[Bug] Fixes for Patch Failures of guns of fury and shrine's legacy

### DIFF
--- a/ports/released/gamemakerengine/gunsoffury/gunsoffury/tools/toggleflags.csx
+++ b/ports/released/gamemakerengine/gunsoffury/gunsoffury/tools/toggleflags.csx
@@ -1,0 +1,45 @@
+#r "UndertaleModLib.dll"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using UndertaleModLib;
+using UndertaleModLib.Models;
+
+EnsureDataLoaded();
+
+var gi = Data.GeneralInfo;
+
+var setStr   = Environment.GetEnvironmentVariable("SET_FLAGS")   ?? "";
+var clearStr = Environment.GetEnvironmentVariable("CLEAR_FLAGS") ?? "";
+
+static IEnumerable<string> SplitFlags(string s) =>
+    string.IsNullOrWhiteSpace(s)
+        ? Enumerable.Empty<string>()
+        : s.Split(new[] { ',', ';', ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+           .Select(x => x.Trim());
+
+static bool TryParseFlag(string name, out UndertaleGeneralInfo.InfoFlags flag)
+{
+    if (Enum.TryParse(name, true, out flag))
+        return true;
+
+    var map = new Dictionary<string, UndertaleGeneralInfo.InfoFlags>(StringComparer.OrdinalIgnoreCase);
+    return map.TryGetValue(name, out flag);
+}
+
+var toSet = SplitFlags(setStr).Select(n => TryParseFlag(n, out var f) ? f : (UndertaleGeneralInfo.InfoFlags?)null).Where(f => f.HasValue).Select(f => f.Value).ToList();
+var toClr = SplitFlags(clearStr).Select(n => TryParseFlag(n, out var f) ? f : (UndertaleGeneralInfo.InfoFlags?)null).Where(f => f.HasValue).Select(f => f.Value).ToList();
+
+UndertaleGeneralInfo.InfoFlags setMask = toSet.Aggregate((UndertaleGeneralInfo.InfoFlags)0, (acc, f) => acc | f);
+UndertaleGeneralInfo.InfoFlags clrMask = toClr.Aggregate((UndertaleGeneralInfo.InfoFlags)0, (acc, f) => acc | f);
+
+var before = gi.Info;
+gi.Info = (before | setMask) & ~clrMask;
+
+string FlagsToNames(UndertaleGeneralInfo.InfoFlags v) =>
+    string.Join(", ", Enum.GetValues(typeof(UndertaleGeneralInfo.InfoFlags))
+        .Cast<UndertaleGeneralInfo.InfoFlags>()
+        .Where(f => f != 0 && v.HasFlag(f)));
+
+ScriptMessage($"[INFO] InfoFlags BEFORE: {before}");
+ScriptMessage($"[INFO] InfoFlags AFTER : {gi.Info}");

--- a/ports/released/gamemakerengine/shrineslegacy/shrineslegacy/tools/patchscript
+++ b/ports/released/gamemakerengine/shrineslegacy/shrineslegacy/tools/patchscript
@@ -96,7 +96,6 @@ dump_textures() {
         echo "[DOTNET]: Texture dumping failed to apply."
         return 1
     else
-        rm -f "$DATADIR/data.win"
         mv "$DATADIR/textures" "$SAVEDIR/textures"
         [ -d "$TMPDIR" ] && rm -rf "$TMPDIR"/*
     fi
@@ -152,6 +151,7 @@ zip_archive() {
 
 # Cleanup function
 cleanup() {
+    rm -f "$DATADIR/data.win"
     rm -rf "$TMPDIR"
     $ESUDO umount "$DOTNETDIR" 2>/dev/null || true
     $ESUDO umount "$TOOLKIT" 2>/dev/null || true


### PR DESCRIPTION
Patches fail for Guns of Fury due to absence of toggleflags.csx and Shrine's legacy due to the script deleting the data.win post texture extraction (when its required for audio extractions as well)

```
 ---> System.IO.FileNotFoundException: Could not find file '/roms/ports/gunsoffury/tools/toggleflags.csx'.
File name: '/roms/ports/gunsoffury/tools/toggleflags.csx'
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.StreamReader.ValidateArgsAndOpenPath(String path, Encoding encoding, Int32 bufferSize)
   at System.IO.File.ReadAllText(String path, Encoding encoding)
   at UndertaleModCli.Program.RunCSharpFile(String path) in /home/johnny/UndertaleModTool_up/UndertaleModCli/Program.cs:line 1021
   at UndertaleModCli.Program.Load(LoadOptions options) in /home/johnny/UndertaleModTool_up/UndertaleModCli/Program.cs:line 294
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.CommandLine.Invocation.ModelBindingCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass23_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass27_0.<<UseVersionOption>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass25_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__24_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass11_0.<<UseDebugDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__10_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass14_0.<<UseExceptionHandler>b__0>d.MoveNext()
Failed to toggle info flags.
Patching process failed!
```


Tested Effectively on RK3566, Powkiddy X55