### PR TITLE
Fix LADXHD Patchscript Failure on Knulli.

### DIFF
--- a/ports/released/zelda-ladxhd/zelda-ladxhd/tools/patchscript
+++ b/ports/released/zelda-ladxhd/zelda-ladxhd/tools/patchscript
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # LADXHD Patcher for Linux ARM64
 # Extracts game from zip, then applies xdelta3 patches to update v1.0.0 to the latest version.
 # Based on the Windows patcher by BigheadSMZ: https://github.com/BigheadSMZ/Zelda-LA-DX-HD-Updated


### PR DESCRIPTION
Change sh to bash to fix shell redirection syntax error when shell not bash by default (_e.g._, Knulli). Thanks!