### PR TITLE
Remove decimals in default for TextboxOverlay.lahdmod

### DIFF
--- a/ports/released/zelda-ladxhd/zelda-ladxhd/data/Mods/LAHDMods/TextboxOverlay.lahdmod
+++ b/ports/released/zelda-ladxhd/zelda-ladxhd/data/Mods/LAHDMods/TextboxOverlay.lahdmod
@@ -2,5 +2,5 @@
 
 // The scaling value used for textboxes. Use a value of "0" to use game default. This value should probably not
 // exceed 6-10 on screens even up to 3840x2160 resolution. Decimal values (like 2.50) are allowed but not recommended.
-// Default: 0.00
-textbox_scale = 0.00
+// Default: 0
+textbox_scale = 0


### PR DESCRIPTION
The extra zeros after the decimal seem to crash the game before the menu can open. Thanks!